### PR TITLE
Fix helm namespace test

### DIFF
--- a/api/internal/target/kusttarget.go
+++ b/api/internal/target/kusttarget.go
@@ -127,7 +127,11 @@ func (kt *KustTarget) MakeCustomizedResMap() (resmap.ResMap, error) {
 }
 
 func (kt *KustTarget) makeCustomizedResMap() (resmap.ResMap, error) {
-	kt.origin = &resource.Origin{}
+       var origin *resource.Origin
+       if len(kt.kustomization.BuildMetadata) != 0 {
+               origin = &resource.Origin{}
+       }
+       kt.origin = origin
 	ra, err := kt.AccumulateTarget()
 	if err != nil {
 		return nil, err

--- a/api/internal/target/kusttarget_configplugin.go
+++ b/api/internal/target/kusttarget_configplugin.go
@@ -44,26 +44,20 @@ func (kt *KustTarget) configureBuiltinGenerators() (
 			return nil, err
 		}
 
-		var generatorOrigin *resource.Origin
-		if kt.origin != nil {
-			generatorOrigin = &resource.Origin{
-				Repo:         kt.origin.Repo,
-				Ref:          kt.origin.Ref,
-				ConfiguredIn: filepath.Join(kt.origin.Path, kt.kustFileName),
-				ConfiguredBy: yaml.ResourceIdentifier{
-					TypeMeta: yaml.TypeMeta{
-						APIVersion: "builtin",
-						Kind:       bpt.String(),
-					},
-				},
-			}
-		} else {
-			generatorOrigin = &resource.Origin{
-				ConfiguredBy: yaml.ResourceIdentifier{
-					TypeMeta: yaml.TypeMeta{APIVersion: "builtin", Kind: bpt.String()},
-				},
-			}
-		}
+               var generatorOrigin *resource.Origin
+               if kt.origin != nil {
+                       generatorOrigin = &resource.Origin{
+                               Repo:         kt.origin.Repo,
+                               Ref:          kt.origin.Ref,
+                               ConfiguredIn: filepath.Join(kt.origin.Path, kt.kustFileName),
+                               ConfiguredBy: yaml.ResourceIdentifier{
+                                       TypeMeta: yaml.TypeMeta{
+                                               APIVersion: "builtin",
+                                               Kind:       bpt.String(),
+                                       },
+                               },
+                       }
+               }
 
 		for i := range r {
 			result = append(result, &resmap.GeneratorWithProperties{Generator: r[i], Origin: generatorOrigin})
@@ -93,26 +87,20 @@ func (kt *KustTarget) configureBuiltinTransformers(
 		if err != nil {
 			return nil, err
 		}
-		var transformerOrigin *resource.Origin
-		if kt.origin != nil {
-			transformerOrigin = &resource.Origin{
-				Repo:         kt.origin.Repo,
-				Ref:          kt.origin.Ref,
-				ConfiguredIn: filepath.Join(kt.origin.Path, kt.kustFileName),
-				ConfiguredBy: yaml.ResourceIdentifier{
-					TypeMeta: yaml.TypeMeta{
-						APIVersion: "builtin",
-						Kind:       bpt.String(),
-					},
-				},
-			}
-		} else {
-			transformerOrigin = &resource.Origin{
-				ConfiguredBy: yaml.ResourceIdentifier{
-					TypeMeta: yaml.TypeMeta{APIVersion: "builtin", Kind: bpt.String()},
-				},
-			}
-		}
+               var transformerOrigin *resource.Origin
+               if kt.origin != nil {
+                       transformerOrigin = &resource.Origin{
+                               Repo:         kt.origin.Repo,
+                               Ref:          kt.origin.Ref,
+                               ConfiguredIn: filepath.Join(kt.origin.Path, kt.kustFileName),
+                               ConfiguredBy: yaml.ResourceIdentifier{
+                                       TypeMeta: yaml.TypeMeta{
+                                               APIVersion: "builtin",
+                                               Kind:       bpt.String(),
+                                       },
+                               },
+                       }
+               }
 		for i := range r {
 			result = append(result, &resmap.TransformerWithProperties{Transformer: r[i], Origin: transformerOrigin})
 		}


### PR DESCRIPTION
## Summary
- revert origin initialization for builtin plugins
- ensure origins only appear when build metadata enabled

## Testing
- `make test-unit-non-plugin` *(fails: accumulating resources via ssh fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_686ceebab3f08333a221c7f749bd173f